### PR TITLE
Fix unrecognized selector error for 'taskIdentifier' and 'originalRequest' methods

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private var globalTaskIdentifier: Int = 100000
+
 final class SessionDataTask: URLSessionDataTask {
 
     // MARK: - Types
@@ -17,6 +19,19 @@ final class SessionDataTask: URLSessionDataTask {
 
     override var response: Foundation.URLResponse? {
         return interaction?.response
+    }
+
+    var _taskIdentifier: Int = {
+      globalTaskIdentifier += 1
+      return globalTaskIdentifier
+    }()
+    override var taskIdentifier: Int {
+      return _taskIdentifier
+    }
+
+    var _originalRequest: URLRequest?
+    override var originalRequest: URLRequest? {
+      return _originalRequest
     }
 
 


### PR DESCRIPTION
Ported from: https://github.com/net-a-porter-mobile/NSURLSession-Mock/blob/master/Pod/Classes/NSURLSession/MockSessionDataTask.swift